### PR TITLE
Lazy imports

### DIFF
--- a/torchapp/apps.py
+++ b/torchapp/apps.py
@@ -416,7 +416,6 @@ class TorchApp(Citable, CLIApp):
         Returns `(lightning_module, trainer)` after training completes.
         """
         import torch
-        from lightning import Trainer
         from lightning import LightningDataModule
 
         style = 'bold red'
@@ -457,7 +456,7 @@ class TorchApp(Citable, CLIApp):
         """
         Validate the model on the validation set.
         """
-        from lightning import Trainer, LightningDataModule
+        from lightning import LightningDataModule
 
         style = 'bold red'
         data = self.setup_and_data(**kwargs)

--- a/torchapp/apps.py
+++ b/torchapp/apps.py
@@ -1,35 +1,31 @@
-from typing import Type
-from importlib import metadata
+from typing import Type, TYPE_CHECKING
 from pathlib import Path
 import os
-import sys
-from collections.abc import Iterable
-import inspect
-import typer
-import torch
-import hashlib
-from torch import nn
-from appdirs import user_cache_dir
-import lightning as L
-from lightning.pytorch.callbacks import RichProgressBar, ModelCheckpoint
-from lightning.pytorch.loggers import CSVLogger, WandbLogger
-from torchmetrics import Metric
-from pytorch_lightning.profilers import Profiler, PyTorchProfiler
+
 from rich.console import Console
 
-from .modules import GeneralLightningModule
-from .callbacks import TimeLoggingCallback, LogOptimizerCallback
 from .cli import CLIApp, method, main, tool, flag
 from .citations import Citable
 from .params import Param
-from .download import cached_download
+
+
+if TYPE_CHECKING:
+    # These are only needed for type-checking (mypy, pylance, etc.)
+    import torch
+    from torch import nn
+    from torchmetrics import Metric
+    from lightning import LightningModule, Trainer, LightningDataModule
+    from lightning.pytorch.callbacks import ModelCheckpoint, Callback
+    from pytorch_lightning.profilers import Profiler
+    from collections.abc import Iterable
+    from .modules import GeneralLightningModule
+
 
 console = Console()
-
 BIBTEX_DIR = Path(__file__).parent / "bibtex"
 
 
-class TorchApp(Citable,CLIApp):
+class TorchApp(Citable, CLIApp):
     @method
     def setup(self) -> None:
         pass
@@ -40,35 +36,50 @@ class TorchApp(Citable,CLIApp):
         ]
 
     @method
-    def model(self) -> nn.Module:
-        raise NotImplementedError(f"Please ensure that the 'model' method is implemented in {self.__class__.__name__}.")
-    
+    def model(self) -> 'nn.Module':
+        raise NotImplementedError(
+            f"Please ensure that the 'model' method is implemented in {self.__class__.__name__}."
+        )
+
     @method
     def loss_function(self):
-        raise NotImplementedError(f"Please ensure that the 'loss_function' method is implemented in {self.__class__.__name__}.")
-    
+        raise NotImplementedError(
+            f"Please ensure that the 'loss_function' method is implemented in {self.__class__.__name__}."
+        )
+
     @method()
-    def data(self) -> Iterable|L.LightningDataModule:
-        raise NotImplementedError(f"Please ensure that the 'data' method is implemented in {self.__class__.__name__}.")
-    
+    def data(self) -> 'Iterable|LightningDataModule':
+        raise NotImplementedError(
+            f"Please ensure that the 'data' method is implemented in {self.__class__.__name__}."
+        )
+
     @method("setup", "data", "validation_dataloader")
-    def setup_and_data(self, **kwargs) -> L.LightningDataModule|Iterable:
-        """ Sets up the app and returns the data. """
+    def setup_and_data(self, **kwargs) -> 'LightningDataModule|Iterable':
+        """
+        Sets up the app and returns either a LightningDataModule or an Iterable (e.g. a DataLoader).
+        """
+        from lightning import LightningDataModule
+
         style = 'bold red'
         console.rule("Setting up app", style=style)
         self.setup(**kwargs)
-        
+
         console.print("Setting up data")
         data = self.data(**kwargs)
-        if isinstance(data, L.LightningDataModule):
+
+        if isinstance(data, LightningDataModule):
             data.setup("fit")
         return data
 
     @method("setup_and_data")
-    def one_batch(self, **kwargs) -> torch.Tensor:
-        """ Returns a single batch of data. """
+    def one_batch(self, **kwargs) -> 'torch.Tensor':
+        """
+        Returns a single batch of data, without labels.
+        """
+        from lightning import LightningDataModule  # to check instance
+
         data = self.setup_and_data(**kwargs)
-        if isinstance(data, L.LightningDataModule):
+        if isinstance(data, LightningDataModule):
             train_dataloader = data.train_dataloader()
         else:
             train_dataloader = data
@@ -78,9 +89,9 @@ class TorchApp(Citable,CLIApp):
             return first_batch[0]
         else:
             return first_batch
-        
+
     @tool("one_batch")
-    def one_batch_size(self, **kwargs) -> torch.Size:
+    def one_batch_size(self, **kwargs) -> 'torch.Size':
         """ Returns the size of a single batch. """
         batch = self.one_batch(**kwargs)
         size = [item.size() for item in batch]
@@ -88,66 +99,92 @@ class TorchApp(Citable,CLIApp):
         return size
     
     @tool("one_batch", "lightning_module")
-    def one_batch_loss(self, **kwargs) -> torch.Tensor:
-        """ Returns the loss of a single batch. """
-        batch = self.one_batch(**kwargs)   
+    def one_batch_loss(self, **kwargs) -> 'torch.Tensor':
+        """
+        Returns the loss (a tensor) of that single batch using the module's training_step.
+        """
+        batch = self.one_batch(**kwargs)
         module = self.lightning_module(**kwargs)
+
+        # We assume LightningModule.training_step(batch, batch_idx) returns a loss-tensor
         loss = module.training_step(batch, batch_idx=0)
         print(loss)
         return loss
-    
+
     @tool("setup_and_data", "lightning_module")
-    def one_batch_output_size(
-        self, 
-        **kwargs
-    ) -> torch.Size:
-        """ Returns the size of the output of a single batch. """
+    def one_batch_output_size(self, **kwargs) -> 'torch.Size':
+        """
+        Returns the shape of the output from model(*inputs) for that single batch.
+        """
+        import torch
+        from lightning import LightningDataModule
+
         data = self.setup_and_data(**kwargs)
         module = self.lightning_module(**kwargs)
-        if isinstance(data, L.LightningDataModule):
+
+        if isinstance(data, LightningDataModule):
             train_dataloader = data.train_dataloader()
         else:
             train_dataloader = data
 
         first_batch = next(iter(train_dataloader))
+
+        # If the batch is a tuple/list, split off inputs up to input_count
         if isinstance(first_batch, (tuple, list)):
-            inputs = first_batch[:module.input_count]
+            inputs = first_batch[: module.input_count]
         else:
             inputs = first_batch
-        
+
+        # Forward-pass through the model
         results = module.model(*inputs)
-        return results.shape if isinstance(results, torch.Tensor) else tuple(result.shape for result in results)
+
+        if isinstance(results, torch.Tensor):
+            return results.shape
+        else:
+            # If model returns a tuple of tensors, return a tuple of shapes
+            return tuple(r.shape for r in results)
 
     @method
-    def validation_dataloader(self) -> Iterable|None:
+    def validation_dataloader(self) -> 'Iterable|None':
         return None
 
     @method
-    def prediction_dataloader(self, module) -> Iterable:
-        raise NotImplementedError(f"Please ensure that the 'prediction_dataloader' method is implemented in {self.__class__.__name__}.")
+    def prediction_dataloader(self, module) -> 'Iterable':
+        raise NotImplementedError(
+            f"Please ensure that the 'prediction_dataloader' method is implemented in {self.__class__.__name__}."
+        )
 
     @method
     def monitor(self) -> str:
         return "valid_loss"
-    
+
     @method
     def goal(self) -> str:
         monitor = self.monitor() or "valid_loss"
         return "minimize" if "loss" in monitor else "maximize"
 
     @method
-    def checkpoint(self, checkpoint:Path=None, **kwargs) -> Path:
-        """ Returns a path to a checkpoint to use for prediction. """
+    def checkpoint(self, checkpoint: Path = None, **kwargs) -> Path:
+        """
+        Returns a path (local or remote) to a checkpoint.  
+        By default, you must override or pass `--checkpoint`.
+        """
         if not checkpoint:
-            raise ValueError("Please provide a checkpoint path or implement the 'checkpoint' method in your app.")
+            raise ValueError(
+                "Please provide a checkpoint path or implement the 'checkpoint' method in your app."
+            )
         return checkpoint
 
     @method("monitor")
-    def checkpoint_callback(self, save_top_k:int=1) -> ModelCheckpoint|list[ModelCheckpoint]:
-        monitor = self.monitor()
+    def checkpoint_callback(self, save_top_k: int = 1) -> 'ModelCheckpoint|list[ModelCheckpoint]':
+        """
+        Build both a Weights-only checkpoint and a full-state checkpoint,
+        saving the top K models based on `monitor`.
+        """
+        from lightning.pytorch.callbacks import ModelCheckpoint
 
-        goal = self.goal()
-        goal = goal.lower()[:3]
+        monitor = self.monitor()
+        goal = self.goal().lower()[:3]
         assert goal in ["min", "max"], f"Goal '{goal}' not recognized."
 
         class WeightsOnlyCheckpoint(ModelCheckpoint):
@@ -156,7 +193,9 @@ class TorchApp(Citable,CLIApp):
                 return "weights_only_checkpoint"
 
         checkpoints = []
-        weights_checkpoint = WeightsOnlyCheckpoint(
+
+        # 1) weights-only checkpoint
+        weights_ckpt = WeightsOnlyCheckpoint(
             save_top_k=save_top_k,
             monitor=monitor,
             mode=goal,
@@ -164,10 +203,10 @@ class TorchApp(Citable,CLIApp):
             filename="weights-{epoch:02d}-{"+monitor+":.2g}",
             verbose=True,
         )
-        # weights_checkpoint.state_key = "weights"
-        checkpoints.append(weights_checkpoint)
+        checkpoints.append(weights_ckpt)
 
-        checkpoint = ModelCheckpoint(
+        # 2) full checkpoint
+        full_ckpt = ModelCheckpoint(
             save_top_k=save_top_k,
             monitor=monitor,
             mode=goal,
@@ -175,50 +214,72 @@ class TorchApp(Citable,CLIApp):
             filename="checkpoint-{epoch:02d}-{"+monitor+":.2g}",
             verbose=True,
         )
-        # checkpoint.state_key = "checkpoint"
-
-        checkpoints.append(checkpoint)
+        checkpoints.append(full_ckpt)
 
         return checkpoints
 
     @method("extra_callbacks")
     def callbacks(self, **kwargs):
+        """
+        Combine all callbacks: 
+        - Always run TimeLoggingCallback and LogOptimizerCallback.
+        - Optionally show a RichProgressBar if running interactively.
+        - Always include the checkpoint callbacks.
+        - Also include any extra_callbacks() provided by the user.
+        """
+        from lightning.pytorch.callbacks import ModelCheckpoint  # needed for isinstance
+        from .callbacks import TimeLoggingCallback, LogOptimizerCallback
+        import sys
+        
         callbacks = [
             TimeLoggingCallback(),
             LogOptimizerCallback(),
         ]
+
+        # If stdout is a TTY, add a nice progress bar
         if sys.stdout.isatty():
+            from rich.progress import RichProgressBar
             callbacks.append(RichProgressBar(leave=True))
 
-        if checkpoint_callbacks := self.checkpoint_callback(**kwargs):
-            if isinstance(checkpoint_callbacks, ModelCheckpoint):
-                checkpoint_callbacks = [checkpoint_callbacks]
-            callbacks.extend(checkpoint_callbacks)
-            
+        # Insert both weight-only and full checkpoints
+        if checkpoint_cbs := self.checkpoint_callback(**kwargs):
+            if isinstance(checkpoint_cbs, ModelCheckpoint):
+                checkpoint_cbs = [checkpoint_cbs]
+            callbacks.extend(checkpoint_cbs)
+
+        # Add any user-defined extra_callbacks
         callbacks += self.extra_callbacks(**kwargs) or []
         return callbacks
-    
-    # Hack - this should be done through calling the 'super' of 'callbacks'
+
     @method
-    def extra_callbacks(self, **kwargs) -> list[L.Callback]:
+    def extra_callbacks(self, **kwargs) -> 'list[Callback]':
+        """
+        If you want to add your own callbacks on top of the defaults,
+        override this. Must return a list of `lightning.pytorch.callbacks.Callback` objects.
+        """
         return []
 
     @method
     def profiler(
         self,
-        profiler_path:Path=None,
-        profile_memory:bool=False,
+        profiler_path: Path = None,
+        profile_memory: bool = False,
         **kwargs,
-    ) -> Profiler|None:
+    ) -> 'Profiler|None':
+        """
+        If `profiler_path` is given, return a PyTorchProfiler that writes to that file.
+        """
+        from pytorch_lightning.profilers import PyTorchProfiler
+
         if profiler_path:
             return PyTorchProfiler(
                 filename=str(profiler_path),
                 profile_memory=profile_memory,
             )
         return None
-    
+
     @method
-    def project_name(self, project_name:str=Param(default="", help="The name of this project (for logging purposes). Defaults to the name of the app."), **kwargs) -> str:
+    def project_name(self, project_name: str = Param(default="", help="The name of this project."), **kwargs) -> str:
         return project_name or self.__class__.__name__
 
     @method("callbacks", "profiler", "project_name")
@@ -235,73 +296,97 @@ class TorchApp(Citable,CLIApp):
         log_every_n_steps:int=50,
         gradient_clip_val:float=Param(None, help="The value to clip the gradients to. If None, then no clipping is done."),
         **kwargs,
-    ) -> L.Trainer:
+    ) -> 'Trainer':
+        """
+        Instantiate and return a Lightning `Trainer`.  
+        - Sets up CSVLogger by default under `output_dir`.  
+        - If `wandb=True`, also sets up a WandbLogger.  
+        - Automatically chooses GPUs if available (up to `max_gpus`).  
+        """
+        import torch
+        from pytorch_lightning.loggers import CSVLogger, WandbLogger
+        from lightning import Trainer
+
         output_dir = Path(output_dir)
         output_dir.mkdir(exist_ok=True, parents=True)
         run_name = run_name or output_dir.name
 
-        loggers = [
-            CSVLogger(save_dir=output_dir),
-        ]
+        # 1) Always have a CSV logger writing to `output_dir`
+        loggers = [CSVLogger(save_dir=output_dir)]
+
+        # 2) If wandb is requested, configure a WandbLogger
         if wandb:
             if wandb_entity:
                 os.environ["WANDB_ENTITY"] = wandb_entity
 
-            project_name = self.project_name(**kwargs)
+            project = self.project_name(**kwargs)
             if wandb_dir:
                 wandb_dir = Path(wandb_dir)
                 wandb_dir.mkdir(exist_ok=True, parents=True)
-            wandb_logger = WandbLogger(name=run_name, project=project_name, offline=wandb_offline, save_dir=wandb_dir)
+
+            wandb_logger = WandbLogger(
+                name=run_name,
+                project=project,
+                offline=wandb_offline,
+                save_dir=wandb_dir,
+            )
             loggers.append(wandb_logger)
-        
-        # If GPUs are available, use all of them; otherwise, use CPUs
-        gpus = torch.cuda.device_count()
+
+        # 3) GPU logic: use all available up to max_gpus; otherwise, use CPUs
+        available_gpus = torch.cuda.device_count()
         if max_gpus:
-            gpus = min(max_gpus, gpus)
-        
-        if gpus > 1:
-            devices = gpus
+            available_gpus = min(max_gpus, available_gpus)
+
+        if available_gpus > 1:
+            devices = available_gpus
             strategy = 'ddp'  # Distributed Data Parallel
         else:
-            devices = "auto"  # Will use CPU if no GPU is available
+            devices = "auto"  # "auto" will pick CPU if no GPU is found
             strategy = "auto"
 
-        return L.Trainer(
+        return Trainer(
             default_root_dir=output_dir,
             accelerator="auto",
-            devices=devices, 
-            strategy=strategy, 
-            logger=loggers, 
+            devices=devices,
+            strategy=strategy,
+            logger=loggers,
             max_epochs=max_epochs,
             callbacks=self.callbacks(**kwargs),
             profiler=self.profiler(**kwargs),
             log_every_n_steps=log_every_n_steps,
             gradient_clip_val=gradient_clip_val,
         )
-    
+
     @method
-    def metrics(self) -> list[tuple[str,Metric]]:
+    def metrics(self) -> 'list[tuple[str,Metric]]':
         return []
-    
+
     @method
     def input_count(self) -> int:
         return 1
-    
+
     @method
     def extra_hyperparameters(self) -> dict:
-        """ Extra hyperparameters to save with the module. """
+        """
+        Any extra hyperparameters to pass to GeneralLightningModule.__init__.
+        """
         return {}
-    
+
     @method
-    def module_class(self) -> Type[GeneralLightningModule]:
+    def module_class(self) -> 'Type[GeneralLightningModule]':
+        from .modules import GeneralLightningModule
         return GeneralLightningModule
-        
+
     @method("model", "loss_function", "extra_hyperparameters", "input_count", "metrics", "module_class")
     def lightning_module(
         self,
-        max_learning_rate:float = 1e-4,
+        max_learning_rate: float = 1e-4,
         **kwargs,
-    ) -> L.LightningModule:
+    ) -> 'LightningModule':
+        """
+        Build and return an instance of your LightningModule subclass,
+        passing in the model, loss, metrics, etc.
+        """
         model = self.model(**kwargs)
         loss_function = self.loss_function(**kwargs)
         metrics = self.metrics(**kwargs)
@@ -317,16 +402,25 @@ class TorchApp(Citable,CLIApp):
             metrics=metrics,
             **extras,
         )
-    
+
     @tool("setup_and_data", "validation_dataloader", "lightning_module", "trainer")
-    def train(
-        self,
-        **kwargs,
-    ) -> L.LightningModule:
-        """Train the model."""
+    def train(self, **kwargs) -> 'LightningModule':
+        """
+        Train for `max_epochs`.  
+        Steps:  
+          1. call setup_and_data → get DataModule or DataLoader  
+          2. call validation_dataloader()  
+          3. instantiate LightningModule + Trainer  
+          4. do a dummy forward-pass (so Lightning can count params)  
+          5. `trainer.fit(...)`  
+        Returns `(lightning_module, trainer)` after training completes.
+        """
+        import torch
+        from lightning import Trainer
+        from lightning import LightningDataModule
+
         style = 'bold red'
         data = self.setup_and_data(**kwargs)
-        
         validation_dataloader = self.validation_dataloader(**kwargs)
 
         console.print("Setting up Module")
@@ -335,27 +429,36 @@ class TorchApp(Citable,CLIApp):
         console.print("Setting up Trainer")
         trainer = self.trainer(**kwargs)
 
-        # Dummy data to set the number of weights in the model
+        # Do one dummy forward to let Lightning “see” the model structure
         console.print("Training Dummy Batch")
         device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-        dummy_batch = next(iter(data.train_dataloader()))
-        dummy_x = dummy_batch[:lightning_module.input_count]
+
+        # get a single train batch
+        if isinstance(data, LightningDataModule):
+            dummy_loader = data.train_dataloader()
+        else:
+            dummy_loader = data
+        dummy_batch = next(iter(dummy_loader))
+
+        # split off inputs
+        dummy_inputs = dummy_batch[: lightning_module.input_count]
         with torch.no_grad():
-            dummy_x = [x.to(device) for x in dummy_x]
+            dummy_inputs = [x.to(device) for x in dummy_inputs]
             model = lightning_module.model.to(device)
-            model(*dummy_x)
+            model(*dummy_inputs)
 
         console.rule("Training", style=style)
-        trainer.fit( lightning_module, data, validation_dataloader )
+        trainer.fit(lightning_module, data, validation_dataloader)
 
         return lightning_module, trainer
 
     @tool("setup_and_data", "load_checkpoint", "trainer")
-    def validate(
-        self,
-        **kwargs,
-    ) -> L.LightningModule:
-        """ Validate the model. """
+    def validate(self, **kwargs) -> 'LightningModule':
+        """
+        Validate the model on the validation set.
+        """
+        from lightning import Trainer, LightningDataModule
+
         style = 'bold red'
         data = self.setup_and_data(**kwargs)
         data.setup("fit")
@@ -368,16 +471,19 @@ class TorchApp(Citable,CLIApp):
         trainer = self.trainer(**kwargs)
 
         console.rule("Validating", style=style)
-        result = trainer.validate( lightning_module, data, validation_dataloader )
+        result = trainer.validate(lightning_module, data, validation_dataloader)
 
         return result
 
-    def process_location(self, location: str, reload:bool=False) -> Path:
+    def process_location(self, location: str, reload: bool = False) -> Path:
         """
-        Process a location string into a Path
-        
-        Can be a URL or a local path.
+        Turn a URL or filesystem path into a Path that points to a local file.
+        If it's a URL, download (and cache) via cached_download().  
         """
+        from pathlib import Path
+        import hashlib
+        from .download import cached_download
+
         location = str(location)
         if location.startswith("http"):
             name = location.split("/")[-1]
@@ -389,23 +495,25 @@ class TorchApp(Citable,CLIApp):
                 name_stem = name
                 extension = ".dat"
             url_hash = hashlib.md5(location.encode()).hexdigest()
-            path = self.cache_dir()/f"{name_stem}-{url_hash}{extension}"
-            cached_download(location, path, force=reload)
-            location = path
+            cache_path = self.cache_dir() / f"{name_stem}-{url_hash}{extension}"
+            cached_download(location, cache_path, force=reload)
+            return cache_path
         else:
-            path = Path(location)
-        
-        return path
+            return Path(location)
 
     @method("checkpoint")
     def load_checkpoint(
-        self, 
+        self,
         reload: bool = Param(
             default=False,
-            help="Should the checkpoint be downloaded again if it is online and already present locally.",
+            help="Should the checkpoint be re-downloaded if it's remote and already exists locally?",
         ),
         **kwargs,
-    ) -> L.LightningModule:
+    ) -> 'LightningModule':
+        """
+        Locate a checkpoint (via `self.checkpoint(...)`), download it if needed,
+        then call `.load_from_checkpoint(...)` on the module class.
+        """
         module_class = self.module_class(**kwargs)
 
         location = self.checkpoint(**kwargs)
@@ -414,19 +522,29 @@ class TorchApp(Citable,CLIApp):
         if not path or not path.is_file():
             raise FileNotFoundError(f"Cannot find pretrained model at '{path}'")
 
-        return module_class.load_from_checkpoint(location)
-        
+        # The class method `load_from_checkpoint` expects the local file path
+        return module_class.load_from_checkpoint(str(path))
+
     def cache_dir(self) -> Path:
-        """ Returns a path to a directory where data files for this app can be cached. """
-        cache_dir = Path(user_cache_dir("torchapps"))/self.__class__.__name__
+        """
+        Returns a directory under the user's cache folder for storing downloads,
+        e.g. `~/.cache/torchapps/<AppName>/`.
+        """
+        from appdirs import user_cache_dir
+        cache_dir = Path(user_cache_dir("torchapps")) / self.__class__.__name__
         cache_dir.mkdir(exist_ok=True, parents=True)
         return cache_dir
-    
+
     @method
-    def prediction_trainer(self, module) -> L.Trainer:
+    def prediction_trainer(self, module) -> 'Trainer':
+        """
+        Return a Trainer for making predictions. By default, just a brand-new Trainer().
+        """
+        from lightning import Trainer
+
         # TODO multigpu
-        return L.Trainer()
-    
+        return Trainer()
+
     @method
     def output_results(self, results, **kwargs):
         raise NotImplementedError(f"Please ensure that the 'output_results' method is implemented in {self.__class__.__name__}.")
@@ -437,58 +555,69 @@ class TorchApp(Citable,CLIApp):
 
     @main("load_checkpoint", "prediction_trainer", "prediction_dataloader", "output_results")
     def predict(self, **kwargs):
-        """ Make predictions with the model. """
+        """
+        Run `trainer.predict(...)` on the data returned by `prediction_dataloader(...)`, 
+        then collate and send to `output_results(...)`.
+        """
+        import torch
+
         module = self.load_checkpoint(**kwargs)
         trainer = self.prediction_trainer(module, **kwargs)
         prediction_dataloader = self.prediction_dataloader(module, **kwargs)
 
-        results = trainer.predict(module, dataloaders=prediction_dataloader)
+        results_list = trainer.predict(module, dataloaders=prediction_dataloader)
 
-        # Concatenate results of prediction batches
-        if len(results) == 0:
+        if not results_list:
             return None
-        if isinstance(results[0], tuple):
-            # zip and cat elements of tuples
-            results = tuple(torch.cat(elements, dim=0) for elements in zip(*results))
-        else:
-            results = torch.cat(results, dim=0)
 
-        return self.output_results(results, **kwargs)        
+        # If each batch returns a tuple, zip-and-concatenate along dim=0
+        first_item = results_list[0]
+        if isinstance(first_item, tuple):
+            results = tuple(
+                torch.cat(elements, dim=0) for elements in zip(*results_list)
+            )
+        else:
+            results = torch.cat(results_list, dim=0)
+
+        return self.output_results(results, **kwargs)
 
     @tool("train", "project_name")
     def tune(
         self,
-        output_dir:Path=Param("./outputs", help="The location of the output directory."),
-        runs: int = Param(default=1, help="The number of runs to attempt to train the model."),
+        output_dir: Path = Param("./outputs", help="Where to write tuning results."),
+        runs: int = Param(default=1, help="Number of parallel runs for tuning."),
         engine: str = Param(
             default="skopt",
-            help="The optimizer to use to perform the hyperparameter tuning. Options: wandb, optuna, skopt.",
-        ),  # should be enum
+            help="Which optimizer to use: 'wandb', 'optuna', or 'skopt'.",
+        ),
         id: str = Param(
             default="",
-            help="The ID of this hyperparameter tuning job. "
-            "If using wandb, then this is the sweep id. "
-            "If using optuna, then this is the storage. "
-            "If using skopt, then this is the file to store the results. ",
+            help="If using wandb: sweep ID. If optuna: storage URL. If skopt: file name.",
         ),
         name: str = Param(
             default="",
-            help="An informative name for this hyperparameter tuning job. If empty, then it creates a name from the project name.",
+            help="An identifier for this tuning job. Defaults to `<project_name>-tuning`.",
         ),
         method: str = Param(
-            default="", help="The sampling method to use to perform the hyperparameter tuning. By default it chooses the default method of the engine."
-        ),  # should be enum
+            default="",
+            help="Sampling method for the tuner (engine-specific).",
+        ),
         min_iter: int = Param(
             default=None,
-            help="The minimum number of iterations if using early termination. If left empty, then early termination is not used.",
+            help="Minimum number of iterations for early stopping (if supported).",
         ),
         seed: int = Param(
             default=None,
-            help="A seed for the random number generator.",
+            help="Random-seed for reproducibility (if supported).",
         ),
         **kwargs,
     ):
-        """ Perform hyperparameter tuning. """
+        """
+        Perform hyperparameter tuning with one of three engines:
+        - wandb (requires a wandb sweep ID),
+        - optuna (requires a storage string),
+        - skopt (requires a file path).
+        """
         if not name:
             name = f"{self.project_name(**kwargs)}-tuning"
 
@@ -536,16 +665,22 @@ class TorchApp(Citable,CLIApp):
                 **kwargs,
             )
         else:
-            raise NotImplementedError(f"Optimizer engine {engine} not implemented.")
+            raise NotImplementedError(f"Optimizer engine '{engine}' not implemented.")
 
     def tuning_params(self):
+        """
+        Inspect the signature of self.tune(...) and return a dict of only
+        those Param() arguments where `Param.tune == True`.  
+        (So that an external tuner can see which hyperparameters are tunable.)
+        """
+        import inspect
+
         tuning_params = {}
         signature = inspect.signature(self.tune)
 
         for key, value in signature.parameters.items():
             default_value = value.default
-            if isinstance(default_value, Param) and default_value.tune == True:
-
+            if isinstance(default_value, Param) and default_value.tune is True:
                 # Override annotation if given in typing hints
                 if value.annotation:
                     default_value.annotation = value.annotation
@@ -553,16 +688,23 @@ class TorchApp(Citable,CLIApp):
                 default_value.check_choices()
 
                 tuning_params[key] = default_value
-                
         return tuning_params
 
     def package_name(self) -> str:
-        module = inspect.getmodule(self)
+        """
+        Attempt to discover this app's package name by:
+        - Checking `__package__` on the module  
+        - Otherwise walking up the filesystem until we find a folder that holds a distribution
+        """
+        import inspect
+        from importlib import metadata
+
+        module_obj = inspect.getmodule(self)
         package = ""
-        if module.__package__:
-            package = module.__package__.split('.')[0]
+        if module_obj and module_obj.__package__:
+            package = module_obj.__package__.split('.')[0]
         else:
-            path = Path(module.__file__).parent
+            path = Path(module_obj.__file__).parent
             while path.name:
                 try:
                     if metadata.distribution(path.name):
@@ -572,36 +714,35 @@ class TorchApp(Citable,CLIApp):
                     pass
                 path = path.parent
         return package
-    
     @flag(shortcut="-v")
     def version(self) -> str:
         """
-        The version of this package.
+        Return the installed version of this package (from `importlib.metadata`).
         """
+        import importlib.metadata as metadata
+
         package = self.package_name()
         if package:
             try:
-                version = metadata.version(package)
-            except metadata.PackageNotFoundError as e:   
+                return metadata.version(package)
+            except metadata.PackageNotFoundError as e:
                 print(e)
                 return ""
-            version = metadata.version(package)
+
         else:
             print("Package name could not be determined.")
             return ""
-        
-        return version
 
     @flag
     def bibtex(self) -> str:
         """
-        The BibTeX entry for this app.
+        Return a combined BibTeX string of all citations in this app.
         """
         return super().bibtex()
-    
+
     @flag
     def bibliography(self) -> str:
         """
-        The bibliography for this app.
+        Return human-readable bibliography entries for this app.
         """
-        return super().bibliography()    
+        return super().bibliography()

--- a/torchapp/enums.py
+++ b/torchapp/enums.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from torch import nn
 
 
 class ActivationError(Exception):
@@ -57,6 +56,8 @@ class Activation(str, Enum):
         Returns:
             nn.Module: The pytorch module for this activation function.
         """
+        from torch import nn
+        
         if not hasattr(nn, self.value):
             raise ActivationError(f"Activation function '{self.value}' not available.")
 


### PR DESCRIPTION
`Torchapp` depends on `torch`, however, `torch` is a very heavy import. This significantly slows down the responsiveness of `torchapp` CLI apps. In this PR I've made aggressive use of lazy importing wherever I can to prevent `torch` from being imported until it is required. This also means you need to slighting change the way you write apps that inherit from `torchapp` so that they also use lazy importing. I've updated a few of the examples to use lazy importing to demonstrate this. 

**Lazy importing results in about a 20x CLI speed up.**

---

Before lazy importing: importing `lightning`, `torch` and `pandas` using >90% of the time just to call `--help`. 

```bash
❯ hyperfine "python torchapp/examples/logistic_regression.py --help"
Benchmark 1: python torchapp/examples/logistic_regression.py --help
  Time (mean ± σ):      3.319 s ±  0.406 s    [User: 3.643 s, System: 1.375 s]
  Range (min … max):    3.072 s …  4.444 s    10 runs
``` 

![image](https://github.com/user-attachments/assets/efc4fc63-0b63-4bcd-a91a-8f7194f6a590)

After lazy importing: `lightning`, `torch` and `pandas` are not imported at all.

```bash
❯ hyperfine "python torchapp/examples/logistic_regression.py --help"                                        
Benchmark 1: python torchapp/examples/logistic_regression.py --help
  Time (mean ± σ):     182.0 ms ±  46.0 ms    [User: 125.3 ms, System: 33.0 ms]
  Range (min … max):   155.2 ms … 311.1 ms    10 runs
```

![image](https://github.com/user-attachments/assets/b94b9b89-662b-459f-ad7f-f09c3e88a8bd)


